### PR TITLE
fix: dedupe duplicate-name othervariables within a category

### DIFF
--- a/lib/rdimensions/reader.rb
+++ b/lib/rdimensions/reader.rb
@@ -87,6 +87,7 @@ module RDimensions
           @labels = Factory.build_labels_for(node)
           @categories = Factory.build_categories_for(self, node)
           @mdm_class = Factory.build_class_for(self, node.at_xpath("class"))
+          @version = node.xpath("versions/version/@name").map {|n| n.value.to_i }.max
         end
       end
     end

--- a/lib/rdimensions/reader.rb
+++ b/lib/rdimensions/reader.rb
@@ -6,7 +6,7 @@ class Nokogiri::XML::Element
 end
 
 module RDimensions
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 
   class Document
     class << self

--- a/lib/rdimensions/variable.rb
+++ b/lib/rdimensions/variable.rb
@@ -4,7 +4,7 @@ module RDimensions
 
   class VariableDefinition < Field
     include Variable
-    attr_reader :min_value, :max_value
+    attr_reader :min_value, :max_value, :version
 
     def has_case_data?
       @has_case_data

--- a/lib/rdimensions/variable_instance.rb
+++ b/lib/rdimensions/variable_instance.rb
@@ -32,7 +32,7 @@ module RDimensions
 
   class Category
     def build_variable_instances(parent_name)
-      othervariables.map {|v| VariableInstance.new("#{parent_name}.#{v.name}", v) }
+      othervariables.uniq(&:name).map {|v| VariableInstance.new("#{parent_name}.#{v.name}", v) }
     end
   end
 

--- a/lib/rdimensions/variable_instance.rb
+++ b/lib/rdimensions/variable_instance.rb
@@ -32,7 +32,11 @@ module RDimensions
 
   class Category
     def build_variable_instances(parent_name)
-      othervariables.uniq(&:name).map {|v| VariableInstance.new("#{parent_name}.#{v.name}", v) }
+      othervariables
+        .each_with_index
+        .group_by {|v, _i| v.name }
+        .map {|_name, pairs| pairs.max_by {|v, i| [v.version || 0, i] }.first }
+        .map {|v| VariableInstance.new("#{parent_name}.#{v.name}", v) }
     end
   end
 

--- a/rdimensions.gemspec
+++ b/rdimensions.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "rdimensions"
-  s.version = "0.2.0"
+  s.version = "0.3.0"
 
   s.authors = ["Scott Brickner"]
   s.email = "scottb@brickner.net"

--- a/spec/r_dimensions/variable_instance_spec.rb
+++ b/spec/r_dimensions/variable_instance_spec.rb
@@ -79,27 +79,45 @@ RSpec.describe RDimensions::VariableInstance do
       <xml><mdm:metadata xmlns:mdm="http://www.spss.com/mr/dm/metadatamodel/Arc 3/2000-02-04">
         <datasources/>
         <definition>
-          <othervariable id="ov-first"  name="Other_specify" type="2" min="0" max="253"/>
-          <othervariable id="ov-second" name="Other_specify" type="2" min="0" max="253"/>
-          <othervariable id="ov-third"  name="Other_specify" type="2" min="0" max="253"/>
-          <othervariable id="ov-other"  name="Other_specify" type="2" min="0" max="253"/>
+          <othervariable id="ov-v1" name="Other_specify" type="2" min="0" max="253">
+            <versions><version name="1"><othervariable name="Other_specify" type="2"/></version></versions>
+          </othervariable>
+          <othervariable id="ov-v8" name="Other_specify" type="2" min="0" max="253">
+            <versions><version name="8"><othervariable name="Other_specify" type="2"/></version></versions>
+          </othervariable>
+          <othervariable id="ov-v18" name="Other_specify" type="2" min="0" max="253">
+            <versions><version name="18"><othervariable name="Other_specify" type="2"/></version></versions>
+          </othervariable>
+          <othervariable id="ov-unversioned-a" name="Plain_other" type="2" min="0" max="253"/>
+          <othervariable id="ov-unversioned-b" name="Plain_other" type="2" min="0" max="253"/>
+          <othervariable id="ov-other" name="Other_specify" type="2" min="0" max="253">
+            <versions><version name="1"><othervariable name="Other_specify" type="2"/></version></versions>
+          </othervariable>
           <variable id="q1-id" name="Q1" type="3" min="1" max="1">
             <categories>
               <category name="Option1"/>
               <category name="Option2">
-                <othervariable ref="ov-first"  name="Other_specify"/>
-                <othervariable ref="ov-second" name="Other_specify"/>
-                <othervariable ref="ov-third"  name="Other_specify"/>
+                <othervariable ref="ov-v8"  name="Other_specify"/>
+                <othervariable ref="ov-v18" name="Other_specify"/>
+                <othervariable ref="ov-v1"  name="Other_specify"/>
               </category>
             </categories>
           </variable>
           <variable id="q2-id" name="Q2" type="3" min="1" max="1">
             <categories>
               <category name="A">
-                <othervariable ref="ov-first" name="Other_specify"/>
+                <othervariable ref="ov-v1" name="Other_specify"/>
               </category>
               <category name="B">
                 <othervariable ref="ov-other" name="Other_specify"/>
+              </category>
+            </categories>
+          </variable>
+          <variable id="q3-id" name="Q3" type="3" min="1" max="1">
+            <categories>
+              <category name="OptionX">
+                <othervariable ref="ov-unversioned-a" name="Plain_other"/>
+                <othervariable ref="ov-unversioned-b" name="Plain_other"/>
               </category>
             </categories>
           </variable>
@@ -108,6 +126,7 @@ RSpec.describe RDimensions::VariableInstance do
         <design><fields>
           <variable ref="q1-id" name="Q1"/>
           <variable ref="q2-id" name="Q2"/>
+          <variable ref="q3-id" name="Q3"/>
         </fields></design>
         <languages base="en-US"/>
         <contexts base="Question"/>
@@ -128,9 +147,14 @@ RSpec.describe RDimensions::VariableInstance do
       expect(instance_names.count("Q2.Other_specify")).to eq 2
     end
 
-    it "keeps the first duplicate in document order" do
+    it "keeps the highest-version duplicate regardless of document order" do
       q1_other = document.variable_instances.find {|vi| vi.name == "Q1.Other_specify" }
-      expect(q1_other.sources.first.uuid).to eq "ov-first"
+      expect(q1_other.sources.first.uuid).to eq "ov-v18"
+    end
+
+    it "falls back to last-wins when duplicates carry no version info" do
+      q3_other = document.variable_instances.find {|vi| vi.name == "Q3.Plain_other" }
+      expect(q3_other.sources.first.uuid).to eq "ov-unversioned-b"
     end
   end
 end

--- a/spec/r_dimensions/variable_instance_spec.rb
+++ b/spec/r_dimensions/variable_instance_spec.rb
@@ -72,4 +72,65 @@ RSpec.describe RDimensions::VariableInstance do
       expect(instance_names).to include("LoopQ27ToQ29[{D}].BlockQ27ToQ29.Q27", "LoopQ27ToQ29[{D}].BlockQ27ToQ29.Q29")
     end
   end
+
+  describe "duplicate othervariables within a category" do
+    let(:mdd) { <<~XML }
+      <?xml version="1.0" encoding="UTF-8"?>
+      <xml><mdm:metadata xmlns:mdm="http://www.spss.com/mr/dm/metadatamodel/Arc 3/2000-02-04">
+        <datasources/>
+        <definition>
+          <othervariable id="ov-first"  name="Other_specify" type="2" min="0" max="253"/>
+          <othervariable id="ov-second" name="Other_specify" type="2" min="0" max="253"/>
+          <othervariable id="ov-third"  name="Other_specify" type="2" min="0" max="253"/>
+          <othervariable id="ov-other"  name="Other_specify" type="2" min="0" max="253"/>
+          <variable id="q1-id" name="Q1" type="3" min="1" max="1">
+            <categories>
+              <category name="Option1"/>
+              <category name="Option2">
+                <othervariable ref="ov-first"  name="Other_specify"/>
+                <othervariable ref="ov-second" name="Other_specify"/>
+                <othervariable ref="ov-third"  name="Other_specify"/>
+              </category>
+            </categories>
+          </variable>
+          <variable id="q2-id" name="Q2" type="3" min="1" max="1">
+            <categories>
+              <category name="A">
+                <othervariable ref="ov-first" name="Other_specify"/>
+              </category>
+              <category name="B">
+                <othervariable ref="ov-other" name="Other_specify"/>
+              </category>
+            </categories>
+          </variable>
+        </definition>
+        <system><fields/></system>
+        <design><fields>
+          <variable ref="q1-id" name="Q1"/>
+          <variable ref="q2-id" name="Q2"/>
+        </fields></design>
+        <languages base="en-US"/>
+        <contexts base="Question"/>
+        <labeltypes base=""/>
+        <routingcontexts base="Web"/>
+        <categorymap/>
+      </mdm:metadata></xml>
+    XML
+
+    let(:document) { RDimensions::Document.parse(mdd) }
+    let(:instance_names) { document.variable_instances.map(&:name) }
+
+    it "collapses duplicate-name siblings into a single instance" do
+      expect(instance_names.count("Q1.Other_specify")).to eq 1
+    end
+
+    it "still produces one instance per category when the same name appears in sibling categories" do
+      expect(instance_names.count("Q2.Other_specify")).to eq 2
+    end
+
+    it "keeps the first duplicate in document order" do
+      q1_other = document.variable_instances.find {|vi| vi.name == "Q1.Other_specify" }
+      expect(q1_other.sources.first.uuid).to eq "ov-first"
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Collapse same-name `<othervariable>` siblings within a single `<category>` into one `VariableInstance`.
- Keep the proxy whose delegate definition has the highest `<versions><version name="N">` value (the most recent MDD edit). Tie-break — including the case where duplicates carry no version info — falls back to last-in-document-order, matching the MDD's normal version-ascending layout.
- Dedup is intentionally per-category; same name in sibling categories still emits one instance per category (those represent genuinely distinct data columns).
- Parses `version` off `VariableDefinition` from the definition's `<versions>` block during read; exposes `#version`. `Category#build_variable_instances` does the grouping/picking.

Closes #2

## Test plan
- [x] New `describe "duplicate othervariables within a category"` block in `spec/r_dimensions/variable_instance_spec.rb` covering:
  - duplicate-name siblings collapse to one instance
  - same name in sibling categories yields one instance *per category*
  - highest-version proxy wins regardless of document order (proxies arranged v8, v18, v1 to differentiate from first/last)
  - no version info → falls back to last-wins
- [x] Sanity-checked against the real `MA10438.mdd` customer file: Q19.Option11, Q46.Option17, Q50.Option18 each collapse to one instance; Q19.Option11 keeps the v18 definition (`f877af3c…`).
- [x] Existing `P4550054.mdd` fixture still yields exactly 236 instances (no duplicates in that file).
- [x] `bundle exec rspec` — 56 examples, 0 failures, 2 pending (pre-existing).
- [ ] Bump consumer (Talaria) to this gem version once published; revert the `mrportal4 → mrportal5` diagnostic in Talaria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)